### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.6+2] - May, 31, 2022
+
+* Automated dependency updates
+
+
 ## [1.1.6+1] - May 14th, 2022
 
 * Added `MapEntry` support.
@@ -51,3 +56,4 @@
 ## [1.0.0] - February 26th, 2022
 
 * Initial Release
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,34 +1,31 @@
-name: template_expressions
-description: A Dart library to process string based templates using expressions.
-homepage: https://github.com/peiffer-innovations/template_expressions
+name: 'template_expressions'
+description: 'A Dart library to process string based templates using expressions.'
+homepage: 'https://github.com/peiffer-innovations/template_expressions'
+version: '1.1.6+2'
 
-version: 1.1.6+1
-
-environment:
+environment: 
   sdk: '>=2.17.0 <3.0.0'
 
-dependencies:
-  convert: ^3.0.1
-  crypto: ^3.0.2
-  encrypt: ^5.0.1
-  fake_async: ^1.3.0
-  intl: ^0.17.0
-  json_class: ^2.1.2+4
+dependencies: 
+  convert: '^3.0.2'
+  crypto: '^3.0.2'
+  encrypt: '^5.0.1'
+  fake_async: '^1.3.0'
+  intl: '^0.17.0'
+  json_class: '^2.1.2+5'
   json_path: '>=0.3.0 <0.5.0'
-  logging: ^1.0.1
-  meta: ^1.7.0
+  logging: '^1.0.2'
+  meta: '^1.7.0'
   petitparser: '>=4.0.2 <6.0.0'
-  pointycastle: ^3.6.0
-  quiver: ^3.1.0
-  rxdart: ^0.27.3
-  yaon: ^1.0.0+1
+  pointycastle: '^3.6.0'
+  quiver: '^3.1.0'
+  rxdart: '^0.27.4'
+  yaon: '^1.0.0+2'
 
-dev_dependencies:
-  test: ^1.21.1
+dev_dependencies: 
+  test: '^1.21.1'
 
-ignore_updates:
-  # Ignoring everything in flutter_test as those are all point-in-time entries
-  # can't upgrade without upgrading Flutter itself.
+ignore_updates: 
   - 'async'
   - 'boolean_selector'
   - 'characters'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `convert`: 3.0.1 --> 3.0.2
  * `json_class`: 2.1.2+4 --> 2.1.2+5
  * `logging`: 1.0.1 --> 1.0.2
  * `rxdart`: 0.27.3 --> 0.27.4
  * `yaon`: 1.0.0+1 --> 1.0.0+2


Analysis Successful

