### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.7+1] - June 21, 2022
+
+* Automated dependency updates
+
+
 ## [1.1.7] - June 16th, 2022
 
 * Fix for escapeing backslash (`\\`)
@@ -55,4 +60,5 @@
 ## [1.0.0] - February 26th, 2022
 
 * Initial Release
+
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'template_expressions'
 description: 'A Dart library to process string based templates using expressions.'
 homepage: 'https://github.com/peiffer-innovations/template_expressions'
-version: '1.1.7'
+version: '1.1.7+1'
 
 environment: 
   sdk: '>=2.17.0 <3.0.0'
@@ -12,7 +12,7 @@ dependencies:
   encrypt: '^5.0.1'
   fake_async: '^1.3.0'
   intl: '^0.17.0'
-  json_class: '^2.1.2+5'
+  json_class: '^2.1.2+6'
   json_path: '>=0.3.0 <0.5.0'
   logging: '^1.0.2'
   meta: '^1.7.0'
@@ -20,10 +20,10 @@ dependencies:
   pointycastle: '^3.6.0'
   quiver: '^3.1.0'
   rxdart: '^0.27.4'
-  yaon: '^1.0.1'
+  yaon: '^1.0.1+1'
 
 dev_dependencies: 
-  test: '^1.21.1'
+  test: '^1.21.2'
 
 ignore_updates: 
   - 'async'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `json_class`: 2.1.2+5 --> 2.1.2+6
  * `yaon`: 1.0.1 --> 1.0.1+1

dev_dependencies:
  * `test`: 1.21.1 --> 1.21.2


Analysis Successful

