### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.7+7] - September 6, 2022
+
+* Automated dependency updates
+
+
 ## [1.1.7+6] - July 28th, 2022
 
 * Revert crypto
@@ -85,6 +90,7 @@
 ## [1.0.0] - February 26th, 2022
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'template_expressions'
 description: 'A Dart library to process string based templates using expressions.'
 homepage: 'https://github.com/peiffer-innovations/template_expressions'
-version: '1.1.7+6'
+version: '1.1.7+7'
 
 environment: 
   sdk: '>=2.17.0 <3.0.0'
@@ -12,7 +12,7 @@ dependencies:
   encrypt: '^5.0.1'
   fake_async: '^1.3.0'
   intl: '^0.17.0'
-  json_class: '^2.1.2+8'
+  json_class: '^2.1.2+9'
   json_path: '>=0.3.0 <0.5.0'
   logging: '^1.0.2'
   meta: '^1.7.0'
@@ -20,10 +20,10 @@ dependencies:
   pointycastle: '^3.6.1'
   quiver: '^3.1.0'
   rxdart: '^0.27.5'
-  yaon: '^1.0.1+3'
+  yaon: '^1.0.1+4'
 
 dev_dependencies: 
-  test: '^1.21.4'
+  test: '^1.21.5'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `json_class`: 2.1.2+8 --> 2.1.2+9
  * `yaon`: 1.0.1+3 --> 1.0.1+4

dev_dependencies:
  * `test`: 1.21.4 --> 1.21.5


Analysis Successful

