### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.7+8] - September 13, 2022
+
+* Automated dependency updates
+
+
 ## [1.1.7+7] - September 6, 2022
 
 * Automated dependency updates
@@ -90,6 +95,7 @@
 ## [1.0.0] - February 26th, 2022
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'template_expressions'
 description: 'A Dart library to process string based templates using expressions.'
 homepage: 'https://github.com/peiffer-innovations/template_expressions'
-version: '1.1.7+7'
+version: '1.1.7+8'
 
 environment: 
   sdk: '>=2.17.0 <3.0.0'
@@ -12,18 +12,18 @@ dependencies:
   encrypt: '^5.0.1'
   fake_async: '^1.3.0'
   intl: '^0.17.0'
-  json_class: '^2.1.2+9'
+  json_class: '^2.1.2+10'
   json_path: '>=0.3.0 <0.5.0'
   logging: '^1.0.2'
   meta: '^1.7.0'
   petitparser: '>=4.0.2 <6.0.0'
-  pointycastle: '^3.6.1'
+  pointycastle: '^3.6.2'
   quiver: '^3.1.0'
   rxdart: '^0.27.5'
-  yaon: '^1.0.1+4'
+  yaon: '^1.0.1+5'
 
 dev_dependencies: 
-  test: '^1.21.5'
+  test: '^1.21.6'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `json_class`: 2.1.2+9 --> 2.1.2+10
  * `pointycastle`: 3.6.1 --> 3.6.2
  * `yaon`: 1.0.1+4 --> 1.0.1+5

dev_dependencies:
  * `test`: 1.21.5 --> 1.21.6


Analysis Successful

