### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.0+3] - December 13, 2022
+
+* Automated dependency updates
+
+
 ## [2.0.0+2] - November 22, 2022
 
 * Automated dependency updates
@@ -125,6 +130,7 @@
 ## [1.0.0] - February 26th, 2022
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'template_expressions'
 description: 'A Dart library to process string based templates using expressions.'
 homepage: 'https://github.com/peiffer-innovations/template_expressions'
-version: '2.0.0+2'
+version: '2.0.0+3'
 
 environment: 
   sdk: '>=2.18.0 <3.0.0'
@@ -12,7 +12,7 @@ dependencies:
   encrypt: '^5.0.1'
   fake_async: '^1.3.0'
   intl: '^0.17.0'
-  json_class: '^2.1.2+13'
+  json_class: '^2.1.2+14'
   json_path: '>=0.3.0 <0.5.0'
   logging: '^1.1.0'
   meta: '^1.7.0'
@@ -20,10 +20,10 @@ dependencies:
   pointycastle: '^3.6.2'
   quiver: '^3.1.0'
   rxdart: '^0.27.7'
-  yaon: '^1.0.1+7'
+  yaon: '^1.0.1+8'
 
 dev_dependencies: 
-  test: '^1.22.0'
+  test: '^1.22.1'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `json_class`: 2.1.2+13 --> 2.1.2+14
  * `yaon`: 1.0.1+7 --> 1.0.1+8

dev_dependencies:
  * `test`: 1.22.0 --> 1.22.1


Analysis Successful

