### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.6+2] - July 4, 2023
+
+* Automated dependency updates
+
+
 ## [3.0.6+1] - June 20, 2023
 
 * Automated dependency updates
@@ -303,6 +308,7 @@
 ## [1.0.0] - February 26th, 2022
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'template_expressions'
 description: 'A Dart library to process string based templates using expressions.'
 homepage: 'https://github.com/peiffer-innovations/template_expressions'
-version: '3.0.6+1'
+version: '3.0.6+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -12,7 +12,7 @@ dependencies:
   encrypt: '^5.0.1'
   fake_async: '^1.3.0'
   intl: '^0.18.1'
-  json_class: '^2.2.2'
+  json_class: '^2.2.2+1'
   json_path: '^0.6.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
@@ -20,11 +20,11 @@ dependencies:
   pointycastle: '^3.7.3'
   quiver: '^3.2.1'
   rxdart: '^0.27.7'
-  yaon: '^1.1.2'
+  yaon: '^1.1.2+1'
 
 dev_dependencies: 
-  flutter_lints: '^2.0.1'
-  test: '^1.24.3'
+  flutter_lints: '^2.0.2'
+  test: '^1.24.4'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_class`: 2.2.2 --> 2.2.2+1
  * `yaon`: 1.1.2 --> 1.1.2+1

dev_dependencies:
  * `flutter_lints`: 2.0.1 --> 2.0.2
  * `test`: 1.24.3 --> 1.24.4


Analysis Successful

