### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.1.1+2] - August 22, 2023
+
+* Automated dependency updates
+
+
 ## [3.1.1+1] - August 15, 2023
 
 * Automated dependency updates
@@ -323,6 +328,7 @@
 ## [1.0.0] - February 26th, 2022
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'template_expressions'
 description: 'A Dart library to process string based templates using expressions.'
 homepage: 'https://github.com/peiffer-innovations/template_expressions'
-version: '3.1.1+1'
+version: '3.1.1+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -16,7 +16,7 @@ dependencies:
   json_path: '^0.6.2'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  petitparser: '^5.4.0'
+  petitparser: '^6.0.1'
   pointycastle: '^3.7.3'
   quiver: '^3.2.1'
   rxdart: '^0.27.7'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `petitparser`: 5.4.0 --> 6.0.1


Error!!!
```
Resolving dependencies...


Because template_expressions depends on json_path ^0.6.2 which depends on petitparser ^5.4.0, petitparser ^5.4.0 is required.
So, because template_expressions depends on petitparser ^6.0.1, version solving failed.


You can try one of the following suggestions to make the pubspec resolve:
* Consider downgrading your constraint on json_path: dart pub add json_path:^0.3.0-nullsafety
* Consider downgrading your constraint on petitparser: dart pub add petitparser:^5.4.0

```

