### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.3.0+3] - November 26, 2024
+
+* Automated dependency updates
+
+
 ## [3.3.0+2] - October 22, 2024
 
 * Automated dependency updates

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: 'template_expressions'
 description: 'A Dart library to process string based templates using expressions.'
 homepage: 'https://github.com/peiffer-innovations/template_expressions'
-version: '3.3.0+2'
+version: '3.3.0+3'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
+dependencies:
   convert: '^3.1.2'
   crypto: '^3.0.1'
   encrypt: '^5.0.3'
   fake_async: '^1.3.0'
-  intl: '^0.19.0'
+  intl: '^0.20.0'
   json_class: '^3.0.0+16'
   json_path: '>=0.6.3 <1.0.0'
   logging: '^1.3.0'
@@ -22,11 +22,11 @@ dependencies:
   rxdart: '^0.28.0'
   yaon: '^1.1.4+10'
 
-dev_dependencies: 
+dev_dependencies:
   flutter_lints: '^5.0.0'
   test: '^1.25.8'
 
-permittedLicenses: 
+permittedLicenses:
   - 'Apache-2.0'
   - 'BSD-2-Clause'
   - 'BSD-3-Clause'
@@ -35,7 +35,7 @@ permittedLicenses:
   - 'MPL-2.0'
   - 'Zlib'
 
-packageLicenseOverride: 
+packageLicenseOverride:
   flutter: 'BSD-3-Clause'
   flutter_driver: 'BSD-3-Clause'
   flutter_goldens: 'BSD-3-Clause'
@@ -46,7 +46,7 @@ packageLicenseOverride:
   integration_test: 'BSD-3-Clause'
   rxdart: 'Apache-2.0'
 
-ignore_updates: 
+ignore_updates:
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `intl`: 0.19.0 --> 0.20.0


Error!!!
```
Resolving dependencies...


Because json_class >=3.0.0+9 depends on intl ^0.19.0 and template_expressions depends on intl ^0.20.0, json_class >=3.0.0+9 is forbidden.
So, because template_expressions depends on json_class ^3.0.0+16, version solving failed.


You can try one of the following suggestions to make the pubspec resolve:
* Consider downgrading your constraint on json_class: dart pub add json_class:^2.1.0
* Consider downgrading your constraint on intl: dart pub add intl:^0.19.0

```

